### PR TITLE
fixed corner case [1,1].lcmByFactors

### DIFF
--- a/Classes/Sieves/lcmExtensions.sc
+++ b/Classes/Sieves/lcmExtensions.sc
@@ -61,6 +61,7 @@
 		args.any(_ == 0).if { ^0 };
 
 		factors = this.abs.factors;
+		(factors == []).if {factors = [1]}{};
 		argListFactors = args.abs.collect(_.factors);
 
 		f = { |dict|


### PR DESCRIPTION
I'd expect that following lines result the same value
```
[1,1].reduce(\lcm);
[1,1].lcmByFactors[1];

```
Actually an empty list is returned in this case.
Probably there's a more elegant way to implement this behaviour.