### PR TITLE
generalize Fb1 checkInits

### DIFF
--- a/Classes/Nonlinear/Fb1.sc
+++ b/Classes/Nonlinear/Fb1.sc
@@ -46,7 +46,7 @@ Fb1 : UGen {
 				buf.set([initItem], buf.numFrames-1)
 			}
 			{ initItem.isKindOf(SequenceableCollection) }{
-				initItem.every(_.isKindOf(Number)).if {
+				initItem.every(_.isValidUGenInput).if {
 					(initItem.size > buf.numFrames).if {
 						SimpleInitError("wrong inInit/outInit data, size too large").throw
 					}{


### PR DESCRIPTION
Since SetLocalBuf accepts any valid UGen input, we can relax the conditions for a valid init of `checkInits`. This will allow to pass initial conditions to ODEs from a Synth.